### PR TITLE
ci: auto-enable auto-merge for Dependabot GitHub Actions PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    # Only act on PRs opened by Dependabot
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auto-enable auto-merge for safe GitHub Actions bumps (minor/patch)
+      - name: Enable auto-merge (squash)
+        if: >
+          steps.meta.outputs.package-ecosystem == 'github-actions' &&
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+           steps.meta.outputs.update-type == 'version-update:semver-patch')
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash


### PR DESCRIPTION
Adds `.github/workflows/dependabot-auto-merge.yml`.

What it does
- On Dependabot PRs that bump **GitHub Actions** only, automatically turns on **Auto-merge (Squash)**.
- Runs on `pull_request_target` but is restricted to `github.actor == dependabot[bot]`.
- Only enables auto-merge for **minor/patch** updates (no majors).
- Respects branch protection: all required checks must pass; if “Require review from Code Owners” is enabled, it still waits for an approval.

Safety notes
- No repo secrets are used; the action only calls GitHub’s API to enable auto-merge on the PR itself.
- Scope limited to Dependabot-authored PRs and the `github-actions` ecosystem.

After merge
- Future Dependabot Actions PRs should show the auto-merge banner and merge themselves once green.
