### PR TITLE
ci(pre-commit): run only on files changed in the PR

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -36,7 +36,9 @@ jobs:
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: ${{ runner.os }}-precommit-
 
-      - name: Run pre-commit
+      - name: Run pre-commit (changed files only)
         uses: pre-commit/action@v3.0.1
         with:
-          extra_args: --all-files --show-diff-on-failure
+          extra_args: |
+            --from-ref ${{ github.event.pull_request.base.sha }}
+            --to-ref   ${{ github.sha }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,13 +1,13 @@
 name: pre-commit
 
 on:
-  pull_request:           # run on PRs into main (make THIS one Required)
+  pull_request:
     branches: [ main ]
 
 permissions:
   contents: read
 
-# Cancel older runs for the same PR/branch
+# Avoid wasting minutes: cancel older runs for the same PR/branch
 concurrency:
   group: pre-commit-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           cache: pip
@@ -39,6 +39,6 @@ jobs:
       - name: Run pre-commit (changed files only)
         uses: pre-commit/action@v3.0.1
         with:
-          extra_args: |
+          extra_args: >-
             --from-ref ${{ github.event.pull_request.base.sha }}
             --to-ref   ${{ github.sha }}


### PR DESCRIPTION
Drop --all-files to lint only changed files in PRs (faster CI).

Keep the same hooks and required checks.